### PR TITLE
Fixing computation

### DIFF
--- a/mmd_loss.py
+++ b/mmd_loss.py
@@ -2,35 +2,85 @@ import torch
 import torch.nn as nn
 
 
-class MMD_loss(nn.Module):
-	def __init__(self, kernel_mul = 2.0, kernel_num = 5):
-		super(MMD_loss, self).__init__()
-		self.kernel_num = kernel_num
-		self.kernel_mul = kernel_mul
-		self.fix_sigma = None
-		return
-	def guassian_kernel(self, source, target, kernel_mul=2.0, kernel_num=5, fix_sigma=None):
-		n_samples = int(source.size()[0])+int(target.size()[0])
-    	total = torch.cat([source, target], dim=0)
 
-    	total0 = total.unsqueeze(0).expand(int(total.size(0)), int(total.size(0)), int(total.size(1)))
-    	total1 = total.unsqueeze(1).expand(int(total.size(0)), int(total.size(0)), int(total.size(1)))
-    	L2_distance = ((total0-total1)**2).sum(2) 
-    	if fix_sigma:
-    		bandwidth = fix_sigma
-    	else:
-    		bandwidth = torch.sum(L2_distance.data) / (n_samples**2-n_samples)
-    	bandwidth /= kernel_mul ** (kernel_num // 2)
-    	bandwidth_list = [bandwidth * (kernel_mul**i) for i in range(kernel_num)]
-    	kernel_val = [torch.exp(-L2_distance / bandwidth_temp) for bandwidth_temp in bandwidth_list]
-    	return sum(kernel_val)
+def broadcast_values(x,y):
+	"""
+	Utility function that make two tensors broadcastable
+	Necessary for computing the kernel
+	"""
+	length_x = len(x.shape)
+	length_y = len(y.shape)
+	#if we consider the 1D dimension kernel 
+	if x.shape[-1]!= y.shape[-1]:
+		#reshaping for broadcasting
+		x_scaled = x.view(*x.shape,*([1]*length_y))
+		y_scaled = y.view(*([1]*length_x),*y.shape)
+		
+	# if we have multiple dimensions
+	elif length_x>1 and length_y>1:
+		x_scaled = x.view(*x.shape[:-1],*([1]*(length_y-1)),x.shape[-1])
+		y_scaled = y.view(*([1]*(length_x-1)),*y.shape)
 
-    def forward(self, source, target):
-    	batch_size = int(source.size()[0])
-    	kernels = guassian_kernel(source, target, kernel_mul=self.kernel_mul, kernel_num=self.kernel_num, fix_sigma=self.fix_sigma)
-    	XX = kernels[:batch_size, :batch_size]
-    	YY = kernels[batch_size:, batch_size:]
-    	XY = kernels[:batch_size, batch_size:]
-    	YX = kernels[batch_size:, :batch_size]
-    	loss = torch.mean(XX + YY - XY -YX)
-    	return loss
+	#case x is 1D
+	elif length_x==1 and length_y>1:
+		x_scaled = x.view(*([1]*(length_y-1)),x.shape[0])
+		y_scaled = y
+
+	#case y is 1D
+	elif length_y==1 and length_x>1:
+		x_scaled = x
+		y_scaled = y.view(*([1]*(length_x-1)),y.shape[0])
+
+	#case are both 1D
+	else:
+		x_scaled=x
+		y_scaled=y
+
+
+	return x_scaled,y_scaled
+
+class GaussianKernel():
+	def __init__(self,sigmas):
+		"""
+		Simple version of the gaussian kernel with 
+		"""
+		self.sigmas_square = sigmas**2
+	def __call__(self,x,y=None):
+		if y is None:
+			y = x
+		x,y = broadcast_values(x,y)
+		L2 = (x-y)**2/self.sigmas_square
+		return torch.exp(torch.sum(-L2,dim=-1))
+
+class MMDLoss(nn.Module):
+	def __init__(self,kernel):
+		super(MMDLoss,self).__init__()
+		"""
+		Function to compute the MMD loss on two samples of data
+		It only works for discrete distributions
+		Parameters:
+			kernel: a callable kernel object
+		"""
+		self.kernel = kernel
+
+	def forward(self,x,y):
+		complete = torch.cat([x,y],dim=0)
+		kernel_complete = self.kernel(complete)
+		size_x = x.shape[0]
+		kernel_x = kernel_complete[:size_x,:size_x]
+		kernel_y = kernel_complete[size_x:,size_x:]
+
+		kernel_xy = kernel_complete[:size_x,size_x:]
+		kernel_yx = kernel_complete[size_x:,:size_x]
+
+
+		return torch.mean(kernel_x) + torch.mean(kernel_y) -torch.mean(kernel_xy) - torch.mean(kernel_yx)
+
+
+
+if __name__ == "__main__":
+	x = torch.randn(1000,4)
+	y = torch.randn(10000,4)
+	gaussiankernel = GaussianKernel(torch.ones(4)*2)
+	loss_fn = MMDLoss(gaussiankernel)
+	print(loss_fn(x,y))


### PR DESCRIPTION
This version inspired from the original code aims at fixing few issues:
    Firstly only one kernel was implemented, I outsourced the kernel so that the potential users can implement whichever they like. They can even make it a nn.Module class so that the gradient can be backpropagated to the kernel itself, one can now implement multiple gaussian kernel as the origin author did but also Mattern or polynomial to plug them to the MMD loss
    Secondly the original code was meant for a source and a target that had the same size which is not the general case, it has been fixed here
    Finally I made a utility function to outsource the broadcasting operations useful for computing the kernel